### PR TITLE
修复农夫AI bug；Fix farmer AI: guard nextValidCell to prevent / by zero

### DIFF
--- a/src/main/java/com/arxyt/colonypathingedition/mixins/minecolonies/farm/EntityAIWorkFarmerMixin.java
+++ b/src/main/java/com/arxyt/colonypathingedition/mixins/minecolonies/farm/EntityAIWorkFarmerMixin.java
@@ -211,6 +211,8 @@ public abstract class EntityAIWorkFarmerMixin extends AbstractEntityAICrafting<J
             }
             worker.getCitizenData().setVisibleStatus(FARMING_ICON);
             worker.getCitizenData().setJobStatus(JobStatus.WORKING);
+            building.setCell(-1);
+            building.setWorkingOffset(null);
             IAIState state = checkNextWorkspaceAndState(farmField,
                     pos -> this.newFindHarvestableSurface(pos, farmField) != null,
                     pos -> this.newFindHoeableSurface(pos, farmField) != null,
@@ -325,6 +327,7 @@ public abstract class EntityAIWorkFarmerMixin extends AbstractEntityAICrafting<J
                 setDelay(getLevelDelay());
             }
 
+            building.setCell(-1);
             building.setWorkingOffset(nextValidCell(farmField));
             IAIState state = checkNextWorkspaceAndState(farmField,
                     pos -> this.newFindHarvestableSurface(pos, farmField) != null,
@@ -363,6 +366,7 @@ public abstract class EntityAIWorkFarmerMixin extends AbstractEntityAICrafting<J
     {
         BlockPos position;
         if(building.getWorkingOffset() == null){
+            building.setCell(-1);
             building.setWorkingOffset(nextValidCell(farmField));
         }
         while(building.getWorkingOffset() != null)


### PR DESCRIPTION
Fixes farmer crash in nextValidCell when ring becomes 0 due to invalid cell state. Adds guards/reset to avoid ArithmeticException and citizen pause.


## 问题根源分析

1. **原始问题**：在 `nextValidCell` 的第 483 行，当计算 `Math.floorDiv(ringCell, 2 * ring)` 时，如果 `ring = 0`，就会导致除以零错误。

2. **为什么 ring 会是 0**：
   - 当 `building.getCell() = -1` 时
   - `ring = (int) Math.floor((Math.sqrt(-1 + 1D) + 1) / 2.0) = (int) Math.floor((0 + 1) / 2.0) = 0`
   - 这导致计算出的 `ring = 0`，触发除以零错误

3. **修复方案**：确保在每次进入 `checkNextWorkspaceAndState` 前，都正确初始化：
   - `building.setCell(-1)` - 将 cell 重置为初始值
   - `building.setWorkingOffset(null)` - 清除工作偏移

## 修改内容

在 `remasteredPrepareForFarming` 方法中，在调用 `checkNextWorkspaceAndState` 前添加了两行初始化代码：

```java
building.setCell(-1);        // 初始化 cell 为 -1
building.setWorkingOffset(null);  // 清除工作偏移
```

这样可以确保无论何时调用 `checkNextWorkspaceAndState`，都会从正确的初始状态开始计算，避免 `ring = 0` 的情况发生。

------------

修正之后用原存档发现其不会再次报错了，且农民行为正常，修正之前即便是破坏农田并重建依然会有问题，原因不明）。

Fixed Bug in #18 